### PR TITLE
Remove scons from base-devel

### DIFF
--- a/scons/PKGBUILD
+++ b/scons/PKGBUILD
@@ -3,10 +3,9 @@
 
 pkgname=scons
 pkgver=3.1.2
-pkgrel=6
+pkgrel=7
 pkgdesc="Extensible Python-based build utility"
 arch=('any')
-groups=('base-devel')
 url="https://scons.org/"
 license=('MIT')
 depends=('python')


### PR DESCRIPTION
scons is an independant buildsystem.